### PR TITLE
DA Fix Test Connection Button

### DIFF
--- a/PlutoHelperAgent/ProjectLockerAndKeychainFunctions.m
+++ b/PlutoHelperAgent/ProjectLockerAndKeychainFunctions.m
@@ -119,7 +119,13 @@ NSString *responseData;
             NSLog(@"Error %@", error);
             errorHandlerBlock(response, error);
         } else {
-            completionHandlerBlock(response,[self parse_json:datastring]);
+            @try {
+                completionHandlerBlock(response,[self parse_json:datastring]);
+            }
+            @catch ( NSException *e ) {
+                NSLog(@"Error %@", e);
+                errorHandlerBlock(response, error);
+            }
         }
     };
 


### PR DESCRIPTION
Code which stops the programme breaking if the 'Test Connection' button is pressed when one or both of the username and password fields are blank.

Tested on a workstation running Mac OS 10.11.

@fredex42 