### PR TITLE
DA Retry Connection if a 403 Error is Thrown

### DIFF
--- a/PlutoHelperAgent/AppDelegate.h
+++ b/PlutoHelperAgent/AppDelegate.h
@@ -25,3 +25,4 @@
 
 @end
 
+extern int connectionAttempts;

--- a/PlutoHelperAgent/AppDelegate.m
+++ b/PlutoHelperAgent/AppDelegate.m
@@ -248,7 +248,9 @@ void (^errorHandlerBlock)(NSURLResponse *response, NSError *error) = ^void(NSURL
                                                                  completionHandler:^(enum ReturnValues loginResult) {
                             if(loginResult!=ALLOK) {
                                 NSLog(@"Could not log in to projectlocker - error was %lu", (unsigned long)loginResult);
-                                [self showError:@"Permission Denied" informativeText:@"Please check you have entered your username and password correctly." showPrefs:YES];
+                                if(loginResult==PERMISSION_DENIED) {
+                                    [self showError:@"Permission Denied" informativeText:@"Please check you have entered your username and password correctly." showPrefs:YES];
+                                }
                             }
                         } errorHandler:^(NSURLResponse *response, NSError *err) {
                             [self setErrorAlert:[err localizedDescription]];

--- a/PlutoHelperAgent/AppDelegate.m
+++ b/PlutoHelperAgent/AppDelegate.m
@@ -20,6 +20,8 @@
 @synthesize statusBar;
 @synthesize connectionWorking;
 
+int connectionAttempts = 0;
+
 - (id)init
 {
     self=[super init];
@@ -231,12 +233,29 @@ void (^errorHandlerBlock)(NSURLResponse *response, NSError *error) = ^void(NSURL
         
     
         [ProjectLockerAndKeychainFunctions check_logged_in:^(enum ReturnValues connectionStatus) {
-            
+
             switch(connectionStatus){
                 case ALLOK:
                     [self tryOpenProject:projectid];
                     break;
                 case PERMISSION_DENIED:
+                    if (connectionAttempts == 0) {
+                        connectionAttempts = connectionAttempts + 1;
+                        NSDictionary *keychainData = [ProjectLockerAndKeychainFunctions load_data_from_keychain];
+                        
+                        [ProjectLockerAndKeychainFunctions login_to_project_server:[keychainData valueForKey:@"username"]
+                                                                          password:[keychainData valueForKey:@"password"]
+                                                                 completionHandler:^(enum ReturnValues loginResult) {
+                            if(loginResult!=ALLOK) {
+                                NSLog(@"Could not log in to projectlocker - error was %lu", (unsigned long)loginResult);
+                                [self showError:@"Permission Denied" informativeText:@"Please check you have entered your username and password correctly." showPrefs:YES];
+                            }
+                        } errorHandler:^(NSURLResponse *response, NSError *err) {
+                            [self setErrorAlert:[err localizedDescription]];
+                            NSLog(@"Could not log in to projectlocker: %@", [err localizedDescription]);
+                        }];
+                        break;
+                    }
                     [self showError:@"Permission Denied" informativeText:@"Please check you have entered your username and password correctly." showPrefs:YES];
                     break;
                 case SERVER_ERROR:


### PR DESCRIPTION
The application will now try again once to log in if it gets a 403 error.

Tested on a machine running Mac OS 10.11.6.

@fredex42 