### PR TITLE
Change Folder Not Found Message

### DIFF
--- a/PlutoHelperAgent/AppDelegate.m
+++ b/PlutoHelperAgent/AppDelegate.m
@@ -216,7 +216,7 @@ void (^errorHandlerBlock)(NSURLResponse *response, NSError *error) = ^void(NSURL
         
         if (!isDir){
             NSLog(@"%@ is not a valid path on this filesystem.", folderToOpen);
-            NSString *errorInfo = [NSString stringWithFormat:@"Could not find folder at %@.\n\nDo you have the Multimedia production drives mounted? If not, rebooting your mac should mount them or try contacting multimediatech@guardian.co.uk for help.", folderToOpen];
+            NSString *errorInfo = [NSString stringWithFormat:@"Could not find the requested folder at:\n\n%@.\n\nDo you have the Multimedia production drives mounted?\n\nIf not, rebooting your mac should mount them or try contacting multimediatech@guardian.co.uk for help.", folderToOpen];
             
             [self basicErrorMessage:@"Asset folder not found" informativeText:errorInfo];
             return;

--- a/PlutoHelperAgent/AppDelegate.m
+++ b/PlutoHelperAgent/AppDelegate.m
@@ -216,7 +216,7 @@ void (^errorHandlerBlock)(NSURLResponse *response, NSError *error) = ^void(NSURL
         
         if (!isDir){
             NSLog(@"%@ is not a valid path on this filesystem.", folderToOpen);
-            NSString *errorInfo = [NSString stringWithFormat:@"Could not find folder at %@.\n\nDo you have the SAN volumes mounted?\n\nContact multimediatech@theguardian.co.uk for help.", folderToOpen];
+            NSString *errorInfo = [NSString stringWithFormat:@"Could not find folder at %@.\n\nDo you have the Multimedia production drives mounted? If not, rebooting your mac should mount them or try contacting multimediatech@guardian.co.uk for help.", folderToOpen];
             
             [self basicErrorMessage:@"Asset folder not found" informativeText:errorInfo];
             return;

--- a/PlutoHelperAgent/Info.plist
+++ b/PlutoHelperAgent/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.0.3</string>
+	<string>2.0.4</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleURLTypes</key>


### PR DESCRIPTION
Changes the text of the message for the folder not found error box.

![image](https://user-images.githubusercontent.com/10620802/47861214-34a34080-ddea-11e8-95c3-4b1bfc3ebf6b.png)

Tested on a machine running Mac OS 10.11.6.

@fredex42 
