### PR TITLE
Changing the Error Message when Opening a Project Fails

### DIFF
--- a/PlutoHelperAgent/AppDelegate.m
+++ b/PlutoHelperAgent/AppDelegate.m
@@ -130,6 +130,7 @@ void (^errorHandlerBlock)(NSURLResponse *response, NSError *error) = ^void(NSURL
                 
                 [task setTerminationHandler:^(NSTask *finishedTask){
                     if([finishedTask terminationStatus]!=0){
+                        NSLog(@"Error attempting to run the script %@ on the path %@. The attempt finished with the status %d.", helperScript, pathToUse, [finishedTask terminationStatus]);
                         //[alert runModal] must be called on main thread. See https://stackoverflow.com/questions/4892182/run-method-on-main-thread-from-another-thread
                         dispatch_async(dispatch_get_global_queue(0, 0), ^{
                             [alert setMessageText:@"Opening Project Failed"];

--- a/PlutoHelperAgent/AppDelegate.m
+++ b/PlutoHelperAgent/AppDelegate.m
@@ -132,11 +132,8 @@ void (^errorHandlerBlock)(NSURLResponse *response, NSError *error) = ^void(NSURL
                     if([finishedTask terminationStatus]!=0){
                         //[alert runModal] must be called on main thread. See https://stackoverflow.com/questions/4892182/run-method-on-main-thread-from-another-thread
                         dispatch_async(dispatch_get_global_queue(0, 0), ^{
-                            [alert setMessageText:@"Open script failed"];
-                            [alert setInformativeText:[NSString stringWithFormat:@"Couldn't open your project, because the open script returned error code %d.\n%@\n%@\n\nPlease contact multimediatech@theguardian.com and send a copy of this message",
-                                                       [finishedTask terminationStatus],
-                                                       [self getPipeData:stdOutPipe],
-                                                       [self getPipeData:stdErrPipe]
+                            [alert setMessageText:@"Opening Project Failed"];
+                            [alert setInformativeText:[NSString stringWithFormat:@"Couldn’t open your project as it appears you may not have all the required Multimedia production drives mounted.\n\nRestarting your Mac should mount the drives, if they still don’t appear try contacting multimediatech@guardian.co.uk and send a copy of this message."
                                                        ]
                              ];
                             [alert setAlertStyle:NSWarningAlertStyle];


### PR DESCRIPTION
Changes the error message when opening a project fails. The new message prompts the user to restart their Mac.

![image](https://user-images.githubusercontent.com/10620802/53806834-f8bdea80-3f45-11e9-9f9d-15aee9755427.png)

Tested on a machine running macOS 10.11.6.

@fredex42 