### PR TITLE
Fix for alert related crashes

### DIFF
--- a/PlutoHelperAgent.xcodeproj/project.pbxproj
+++ b/PlutoHelperAgent.xcodeproj/project.pbxproj
@@ -347,7 +347,7 @@
 				INFOPLIST_FILE = PlutoHelperAgent/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 10.8;
-				MARKETING_VERSION = 2.1;
+				MARKETING_VERSION = 2.2;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 			};
 			name = Debug;
@@ -361,7 +361,7 @@
 				INFOPLIST_FILE = PlutoHelperAgent/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 10.8;
-				MARKETING_VERSION = 2.1;
+				MARKETING_VERSION = 2.2;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 			};
 			name = Release;


### PR DESCRIPTION
try to fix crashes by ensuring that alerts are always performed on the main thread

## What does this change?
On the newer Macs unexpected crashes were observed when attempting to open projects.
The root cause appears to have been initiating and displaying alerts from subthreads.

This PR fixes the issue by ensuring that alerts are carried out on the main thread always

## How to test
It should crash less!

## How can we measure success?
Less crashes / complaints

